### PR TITLE
Fix exception when viewPortNode has no child

### DIFF
--- a/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
+++ b/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
@@ -81,9 +81,10 @@ public class ViewportPanel extends Panel {
                     viewPortNode.updateLogicalState(tpf);
 
                     if(autoZoom) {
-                        Spatial child = viewPortNode.getChild(0);
-                        if(child != null) {
-
+                        
+                        if(viewPortNode.getQuantity() > 0) {
+                            
+                            Spatial child = viewPortNode.getChild(0);
                             viewPortNode.updateModelBound();
 
                             //FIXME: When rotating, the bounds dimension can change, making the y be bigger than the x or z and viceverse, showing an undesired zoom-in-out effect.


### PR DESCRIPTION
java.lang.ArrayIndexOutOfBoundsException: 0
	at com.jme3.util.SafeArrayList.get(SafeArrayList.java:276) ~[jme3-core-3.2.0-SNAPSHOT.jar:3.2-6142]
	at com.jme3.scene.Node.getChild(Node.java:499) ~[jme3-core-3.2.0-SNAPSHOT.jar:3.2-6142]