### PR TITLE
BoundingBox caching in viewport panel

### DIFF
--- a/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
+++ b/src/main/java/com/nx/util/jme3/lemur/panel/ViewportPanel.java
@@ -62,6 +62,12 @@ public class ViewportPanel extends Panel {
     protected final Transform realTransform = new Transform();
 
     protected boolean autoZoom = true;
+    protected BoundingBox cachedBB = null;
+    
+    public void cacheBB() {
+        Spatial child = viewPortNode.getChild(0);
+        cachedBB = (BoundingBox) child.getWorldBound().clone();
+    }
 
     private final Vector3f lastPosition =new Vector3f ();
 //    private Node rootNode;
@@ -93,7 +99,10 @@ public class ViewportPanel extends Panel {
                     viewPortNode.updateModelBound();
 
                     //FIXME: When rotating, the bounds dimension can change, making the y be bigger than the x or z and viceverse, showing an undesired zoom-in-out effect.
-                    BoundingBox bb = (BoundingBox) child.getWorldBound();
+                    BoundingBox bb;
+                    if (cachedBB == null)
+                        bb = (BoundingBox) child.getWorldBound();
+                    else bb = cachedBB;
                     if (bb != null) {
                         float x = bb.getXExtent();
                         float y = bb.getYExtent();


### PR DESCRIPTION
Removes undesired zoom effect after the bounding box is cached. This is just a simple solution to fix the problem. I had a rotating 3d coin... that didn't end well.